### PR TITLE
Handle pagination exceptions

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,6 +5,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS, cross_origin
 
 from app.middleware.pagination import paginate
+from app.errors import InvalidUsage
 
 RDF_URI = os.getenv('RDF_URI', 'http://localhost:3030')
 RDF_STORE = os.getenv('RDF_STORE', 'store')
@@ -213,3 +214,10 @@ def resource_names():
     # print("JSON:", json_string)
 
     return jsonify(page=page, offset=offset, limit=limit, data=data)
+
+
+@app.errorhandler(InvalidUsage)
+def handle_invalid_usage(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response

--- a/app/app.py
+++ b/app/app.py
@@ -4,8 +4,8 @@ import urllib.parse
 from flask import Flask, request, jsonify
 from flask_cors import CORS, cross_origin
 
-from app.middleware.pagination import paginate
-from app.errors import InvalidUsage
+from .errors import InvalidUsage
+from .middleware.pagination import paginate
 
 RDF_URI = os.getenv('RDF_URI', 'http://localhost:3030')
 RDF_STORE = os.getenv('RDF_STORE', 'store')

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,15 @@
+
+class InvalidUsage(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = self.message
+        return rv

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,13 +1,12 @@
 
 class InvalidUsage(Exception):
-    status_code = 400
+    DEFAULT_CODE = 400
 
-    def __init__(self, message, status_code=None, payload=None):
+    def __init__(self, message, payload=None, status_code=None):
         Exception.__init__(self)
         self.message = message
-        if status_code is not None:
-            self.status_code = status_code
         self.payload = payload
+        self.status_code = status_code or self.DEFAULT_CODE
 
     def to_dict(self):
         rv = dict(self.payload or ())

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,5 +1,16 @@
+"""
+A module for managing errors.
+"""
+
 
 class InvalidUsage(Exception):
+    """
+    Generic class to handle requests' exceptions.
+
+    Adapted from: http://flask.pocoo.org/docs/0.11/patterns/apierrors/
+    ======= =====
+    """
+
     DEFAULT_CODE = 400
 
     def __init__(self, message, payload=None, status_code=None):

--- a/app/middleware/pagination.py
+++ b/app/middleware/pagination.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from flask import request
+from app.errors import InvalidUsage
 
 KEY = "page"
 LIMIT = 100
@@ -10,8 +11,14 @@ def paginate(limit=LIMIT, initial=INITIAL):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            # TODO: catch parsing exceptions
-            page = max(int(request.args.get(KEY, initial)), 0)
+            try:
+                initial_ = request.args.get(KEY, initial)
+                page = max(int(initial_), 0)
+            except ValueError:
+                ERROR_MESSAGE = ("{} is not a valid page format. "
+                                 "Please, use an integer.")
+                raise InvalidUsage(ERROR_MESSAGE.format(initial_),
+                                   status_code=400)
             limited = max(min(int(request.args.get("limit", limit)), limit), 0)
             offset = page * limited
             request.pagination = {

--- a/app/middleware/pagination.py
+++ b/app/middleware/pagination.py
@@ -1,5 +1,5 @@
-from functools import wraps
 from flask import request
+from functools import wraps
 from app.errors import InvalidUsage
 
 KEY = "page"


### PR DESCRIPTION
# Descripción

Esto debería manejar (casi) todas las excepciones al momento de paginar.
Además, ofrece una clase genérica para fabricar otras (futuras) excepciones.
No he realizado _tests_ unitarios todavía, puesto que la idea es migrar a [py.test](http://docs.pytest.org/en/latest).
Considero, entonces, que hacer ambos cambios en un mismo _pull request_ no es adecuado.
# Ejemplo

Realizar un `GET` a la ruta `/courses?page=forty-two` producía un _internal server error_,
puesto que intentaba hacer un infructuoso _cast_ del argumento `forty-two`.
Sin embargo, este _pull request_ busca manejar este caso, entregando un error `400`,
acompañado de un mensaje explicativo. :information_desk_person:
En este caso, se respondería con el siguiente JSON,

``` json
{
  "message": "forty-two is not a valid page format. Please, use an integer."
}
```

Finalmente, hay que mencionar que este _pull request_ es perfectible.
Todo es perfectible: Git es perfectible, GitHub es perfectible, ¡hasta la Capilla Sixtina es perfectible!
